### PR TITLE
Add `validate_certs=false` to each task

### DIFF
--- a/tasks/ext-apcu.yml
+++ b/tasks/ext-apcu.yml
@@ -1,7 +1,7 @@
 ---
 
 - name: Fetch apcu .deb
-  get_url: url=https://ftp.weheartwebsites.de/{{ ansible_distribution | lower }}/{{ ansible_distribution_release }}/php5-apcu_{{ php5fpm_ext_apcu_version }}_amd64.deb dest=/tmp/php5-apcu_{{ php5fpm_ext_apcu_version }}_amd64.deb
+  get_url: url=https://ftp.weheartwebsites.de/{{ ansible_distribution | lower }}/{{ ansible_distribution_release }}/php5-apcu_{{ php5fpm_ext_apcu_version }}_amd64.deb dest=/tmp/php5-apcu_{{ php5fpm_ext_apcu_version }}_amd64.deb validate_certs=false
 
 - name: Install apcu .deb
   apt: deb=/tmp/php5-apcu_{{ php5fpm_ext_apcu_version }}_amd64.deb

--- a/tasks/ext-igbinary.yml
+++ b/tasks/ext-igbinary.yml
@@ -1,7 +1,7 @@
 ---
 
 - name: Fetch igbinary .deb
-  get_url: url=https://ftp.weheartwebsites.de/{{ ansible_distribution | lower }}/{{ ansible_distribution_release }}/php5-igbinary_{{ php5fpm_ext_igbinary_version }}_amd64.deb dest=/tmp/php5-igbinary_{{ php5fpm_ext_igbinary_version }}_amd64.deb
+  get_url: url=https://ftp.weheartwebsites.de/{{ ansible_distribution | lower }}/{{ ansible_distribution_release }}/php5-igbinary_{{ php5fpm_ext_igbinary_version }}_amd64.deb dest=/tmp/php5-igbinary_{{ php5fpm_ext_igbinary_version }}_amd64.deb validate_certs=false
 
 - name: Install igbinary .deb
   apt: deb=/tmp/php5-igbinary_{{ php5fpm_ext_igbinary_version }}_amd64.deb

--- a/tasks/ext-imagick.yml
+++ b/tasks/ext-imagick.yml
@@ -11,7 +11,7 @@
   when: ansible_distribution == 'Ubuntu'
 
 - name: Fetch imagick .deb
-  get_url: url=https://ftp.weheartwebsites.de/{{ ansible_distribution | lower }}/{{ ansible_distribution_release }}/php5-imagick_{{ php5fpm_ext_imagick_version }}_amd64.deb dest=/tmp/php5-imagick_{{ php5fpm_ext_imagick_version }}_amd64.deb
+  get_url: url=https://ftp.weheartwebsites.de/{{ ansible_distribution | lower }}/{{ ansible_distribution_release }}/php5-imagick_{{ php5fpm_ext_imagick_version }}_amd64.deb dest=/tmp/php5-imagick_{{ php5fpm_ext_imagick_version }}_amd64.deb validate_certs=false
 
 - name: Install imagick .deb
   apt: deb=/tmp/php5-imagick_{{ php5fpm_ext_imagick_version }}_amd64.deb

--- a/tasks/ext-memcached.yml
+++ b/tasks/ext-memcached.yml
@@ -15,7 +15,7 @@
   become: yes
 
 - name: Fetch memcached .deb
-  get_url: url=https://ftp.weheartwebsites.de/{{ ansible_distribution | lower }}/{{ ansible_distribution_release }}/php5-memcached_{{ php5fpm_ext_memcached_version }}_amd64.deb dest=/tmp/php5-memcached_{{ php5fpm_ext_memcached_version }}_amd64.deb
+  get_url: url=https://ftp.weheartwebsites.de/{{ ansible_distribution | lower }}/{{ ansible_distribution_release }}/php5-memcached_{{ php5fpm_ext_memcached_version }}_amd64.deb dest=/tmp/php5-memcached_{{ php5fpm_ext_memcached_version }}_amd64.deb validate_certs=false
 
 - name: Install memcached .deb
   apt: deb=/tmp/php5-memcached_{{ php5fpm_ext_memcached_version }}_amd64.deb

--- a/tasks/ext-redis.yml
+++ b/tasks/ext-redis.yml
@@ -1,7 +1,7 @@
 ---
 
 - name: Fetch redis .deb
-  get_url: url=https://ftp.weheartwebsites.de/{{ ansible_distribution | lower }}/{{ ansible_distribution_release }}/php5-redis_{{ php5fpm_ext_redis_version }}_amd64.deb dest=/tmp/php5-redis_{{ php5fpm_ext_redis_version }}_amd64.deb
+  get_url: url=https://ftp.weheartwebsites.de/{{ ansible_distribution | lower }}/{{ ansible_distribution_release }}/php5-redis_{{ php5fpm_ext_redis_version }}_amd64.deb dest=/tmp/php5-redis_{{ php5fpm_ext_redis_version }}_amd64.deb validate_certs=false
 
 - name: Install redis .deb
   apt: deb=/tmp/php5-redis_{{ php5fpm_ext_redis_version }}_amd64.deb

--- a/tasks/php-fpm.yml
+++ b/tasks/php-fpm.yml
@@ -27,7 +27,7 @@
   when: ansible_distribution == 'Ubuntu'
 
 - name: Fetch .deb
-  get_url: url=https://ftp.weheartwebsites.de/{{ ansible_distribution | lower }}/{{ ansible_distribution_release }}/php5-fpm_{{ php5fpm_version }}_amd64.deb dest=/tmp/php5-fpm_{{ php5fpm_version }}_amd64.deb
+  get_url: url=https://ftp.weheartwebsites.de/{{ ansible_distribution | lower }}/{{ ansible_distribution_release }}/php5-fpm_{{ php5fpm_version }}_amd64.deb dest=/tmp/php5-fpm_{{ php5fpm_version }}_amd64.deb validate_certs=false
 
 - name: Install .deb
   apt: deb=/tmp/php5-fpm_{{ php5fpm_version }}_amd64.deb


### PR DESCRIPTION
Not the best solution, temporary fix to ignore SSL certs on the `get_url` tasks until this is resolved.